### PR TITLE
Replaces string_to_gnc_numeric function with gnc_numeric_from_string.

### DIFF
--- a/src/NetCash.Core/Bindings.fs
+++ b/src/NetCash.Core/Bindings.fs
@@ -235,8 +235,8 @@ extern GNCNumericErrorCode  gnc_numeric_check(gnc_numeric a)
 [<DllImport(NativeLibraries.gncEngine)>]
 extern gint gnc_numeric_compare(gnc_numeric a, gnc_numeric b)
 
-[<DllImport(NativeLibraries.gncEngine); return: MarshalAs(UnmanagedType.I1)>]
-extern bool string_to_gnc_numeric([<MarshalAs(UnmanagedType.LPUTF8Str)>]string str, gnc_numeric& n)
+[<DllImport(NativeLibraries.gncEngine)>]
+extern gnc_numeric gnc_numeric_from_string([<MarshalAs(UnmanagedType.LPUTF8Str)>]string str)
 
 [<DllImport(NativeLibraries.gncEngine)>]
 extern nativeint gnc_numeric_errorCode_to_string(GNCNumericErrorCode error_code)

--- a/src/NetCash.Core/GncNumeric.fs
+++ b/src/NetCash.Core/GncNumeric.fs
@@ -62,8 +62,11 @@ type GncNumeric =
         |> GncNumeric
 
     static member private FromString(s) =
-        let mutable n = Bindings.gnc_numeric_zero ()
-        (Bindings.string_to_gnc_numeric (s, &n), n)
+        let n = Bindings.gnc_numeric_from_string (s)
+        if Bindings.gnc_numeric_check(n) = Bindings.GNCNumericErrorCode.GNC_ERROR_OK then
+            (true, n)
+        else  // Note: TryParse expects a valid gnc_numeric object, even when we return false. Use zero as a default.
+            (false, Bindings.gnc_numeric_zero())
 
     static member Parse(s) =
         let (success, n) = GncNumeric.FromString s


### PR DESCRIPTION
The function was renamed in GnuCash commit https://github.com/Gnucash/gnucash/commit/c45b9736ab9a78f7ab807c274f61ff1eda695dbf It looks like that was first released with GnuCash 5.4.